### PR TITLE
Require factory_girl in seeds.rb

### DIFF
--- a/lib/factory_girl-seeds/seeds.rb
+++ b/lib/factory_girl-seeds/seeds.rb
@@ -1,3 +1,5 @@
+require 'factory_girl'
+
 module FactoryGirl
   class SeedGenerator
     @ids = {}


### PR DESCRIPTION
Fixes some issues where factory_girl-seeds loads before factory_girl. Shouldn't cause compatibility issues since 'require' is only run once.
