### PR TITLE
Adding support to attributes to seed method

### DIFF
--- a/lib/factory_girl-seeds/seeds.rb
+++ b/lib/factory_girl-seeds/seeds.rb
@@ -7,20 +7,21 @@ module FactoryGirl
 
     def self.create(factory_name, *attributes)
       model = FactoryGirl.create(factory_name, *attributes)
-      @ids[factory_name] = model.id
+      @ids[factory_name.to_s + attributes.to_s] = model.id
       @classes[factory_name] = model.class
 
       model
     end
 
-    def self.[](factory_name)
-      seed_id = @ids[factory_name]
+    def self.[](factory_name, *attributes)
+      seed_id = @ids[factory_name.to_s + attributes.to_s]
 
       if seed_id
         seed_class = @classes[factory_name]
-        seed_class.where(seed_class.primary_key => seed_id).first || create(factory_name)
+        seed_class.where(seed_class.primary_key => seed_id).first ||
+          create(factory_name, *attributes)
       else
-        create(factory_name)
+        create(factory_name, *attributes)
       end
     end
   end
@@ -29,11 +30,11 @@ end
 module FactoryGirl
   module Syntax
     module SeedMethods
-      def seed(factory_name)
+      def seed(factory_name, *attributes)
         if defined?(Rails) && !Rails.env.test?
-          FactoryGirl.create(factory_name)
+          FactoryGirl.create(factory_name, *attributes)
         else
-          FactoryGirl::SeedGenerator[factory_name]
+          FactoryGirl::SeedGenerator[factory_name, *attributes]
         end
       end
     end

--- a/spec/factory_girl-seeds/seeds_spec.rb
+++ b/spec/factory_girl-seeds/seeds_spec.rb
@@ -31,5 +31,9 @@ describe FactoryGirl do
     it do
       expect(FactoryGirl.seed(:user)).to be
     end
+
+    it do
+      expect(FactoryGirl.seed(:user, name: "dev").name).to eq("dev")
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,8 +2,10 @@ require 'factory_girl'
 require 'active_record'
 require 'factory_girl-seeds'
 
-ActiveRecord::Base.configurations = {'test' => {:adapter => 'sqlite3', :database => ':memory:'}}
-ActiveRecord::Base.establish_connection('test')
+ActiveRecord::Base.establish_connection(
+  adapter: "sqlite3",
+  database: ":memory:"
+)
 
 ActiveRecord::Migration.verbose = false
 ActiveRecord::Schema.define(version: 0) do


### PR DESCRIPTION
Hi,

this PR add support to attributes when calling method `seed`.

When my spec needs multiple factories with different attributes and used in many blocks, usually I build something like this:
```ruby
describe User, type: model do
  before do
    user1 = create(:user, name: 'dev1')
    user2 = create(:user, name: 'dev2')
  end

  it {}
  it {}
end
```

So now, we can use `seed` for these cases as well:
```ruby
describe User, type: model do
  before do
    user1 = seed(:user, name: 'dev1')
    user2 = seed(:user, name: 'dev2')
  end
```

Please merge if you think this is useful.

Thanks.